### PR TITLE
Extend the role to allow linking to entire repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ MyST:
 ```{code-block} md
 :caption: index.md
 See {github}`astrojuanlu/sphinx-github-role#1`.
+This project depends on {github}`sphinx-doc/sphinx`.
 ```
 
 reStructuredText:
@@ -44,6 +45,7 @@ reStructuredText:
 ```{code-block} rst
 :caption: index.rst
 See :github:`astrojuanlu/sphinx-github-role#1`.
+This project depends on :github:`sphinx-doc/sphinx`.
 ```
 
 ### Configuring a default organization and project
@@ -77,6 +79,8 @@ you only need to type this:
 :caption: index.md
 See {github}`#1`.
 ```
+
+For repository links, only the `default_org` is relevant.
 
 ### Customizing link text
 

--- a/src/sphinx_github_role/__init__.py
+++ b/src/sphinx_github_role/__init__.py
@@ -60,7 +60,6 @@ class GitHub(ReferenceRole):
         try:
             parts = match.groupdict()
         except AttributeError as exc:
-            print(self.target)
             raise ValueError(f"Malformed link '{self.rawtext}'") from exc
 
         proj_only = parts["proj_only"]
@@ -75,17 +74,10 @@ class GitHub(ReferenceRole):
             )
 
         if proj_only:
-            node = nodes.reference(
-                self.rawtext,
-                self.title,
-                refuri=self.gh_tpl.format(**parts),
-            )
+            refuri = self.gh_tpl.format(**parts)
         else:
-            node = nodes.reference(
-                self.rawtext,
-                self.title,
-                refuri=self.gh_issue_tpl.format(**parts),
-            )
+            refuri = self.gh_issue_tpl.format(**parts)
+        node = nodes.reference(self.rawtext, self.title, refuri=refuri)
 
         return [node], []
 

--- a/src/sphinx_github_role/__init__.py
+++ b/src/sphinx_github_role/__init__.py
@@ -41,15 +41,17 @@ def setup_github_role(_: Sphinx, config: Config) -> None:
 
 
 class GitHub(ReferenceRole):
-    # For example: org/proj#1
+    # For example: org/proj#1 or org/proj
     gh_re = re.compile(
         r"""((?P<org>.+)/)?  # Optional organization
-        (?P<proj>.+)?  # Optional project
-        \#(?P<num>\d+)  # Issue or pull request id""",
+        (?:(?P<proj>.+)?  # Optional project
+        \#(?P<num>\d+) # Issue or pull request id
+        |(?P<proj_only>[^\#]+)) # bare project""",
         re.VERBOSE,
     )
     # The /issues/{num} and /pull/{num} URLs automatically redirect
-    gh_tpl = "https://github.com/{org}/{proj}/issues/{num}"
+    gh_issue_tpl = "https://github.com/{org}/{proj}/issues/{num}"
+    gh_tpl = "https://github.com/{org}/{proj}/"
 
     def run(self) -> tuple[list[Node], list[system_message]]:
         # breakpoint()
@@ -58,10 +60,12 @@ class GitHub(ReferenceRole):
         try:
             parts = match.groupdict()
         except AttributeError as exc:
+            print(self.target)
             raise ValueError(f"Malformed link '{self.rawtext}'") from exc
 
+        proj_only = parts["proj_only"]
         parts["org"] = parts["org"] or _DEFAULTS[0]
-        parts["proj"] = parts["proj"] or _DEFAULTS[1]
+        parts["proj"] = parts["proj"] or proj_only or _DEFAULTS[1]
         if not parts["org"] or not parts["proj"]:
             raise ValueError(
                 "Incomplete configuration or GitHub reference: "
@@ -70,11 +74,18 @@ class GitHub(ReferenceRole):
                 f"role text = '{self.rawtext}'"
             )
 
-        node = nodes.reference(
-            self.rawtext,
-            self.title,
-            refuri=self.gh_tpl.format(**parts),
-        )
+        if proj_only:
+            node = nodes.reference(
+                self.rawtext,
+                self.title,
+                refuri=self.gh_tpl.format(**parts),
+            )
+        else:
+            node = nodes.reference(
+                self.rawtext,
+                self.title,
+                refuri=self.gh_issue_tpl.format(**parts),
+            )
 
         return [node], []
 

--- a/tests/cases/test-repo-default-org/conf.py
+++ b/tests/cases/test-repo-default-org/conf.py
@@ -1,0 +1,7 @@
+extensions = [
+    "sphinx_github_role",
+]
+
+github_default_org_project = ("readthedocs", None)
+
+nitpicky = True

--- a/tests/cases/test-repo-default-org/index.rst
+++ b/tests/cases/test-repo-default-org/index.rst
@@ -1,0 +1,4 @@
+Hello, world!
+=============
+
+Sample :github:`readthedocs.org` repository.

--- a/tests/cases/test-repo/conf.py
+++ b/tests/cases/test-repo/conf.py
@@ -1,0 +1,5 @@
+extensions = [
+    "sphinx_github_role",
+]
+
+nitpicky = True

--- a/tests/cases/test-repo/index.rst
+++ b/tests/cases/test-repo/index.rst
@@ -1,0 +1,4 @@
+Hello, world!
+=============
+
+Sample :github:`sphinx-doc/sphinx` role.

--- a/tests/test_github_role.py
+++ b/tests/test_github_role.py
@@ -36,7 +36,9 @@ def test_github_role_produces_html_hyperlink(app: SphinxTestApp) -> None:
 def test_malformed_link_raises_error(
     app: SphinxTestApp,
 ) -> None:
-    with pytest.raises(ValueError, match="Malformed link"):
+    with pytest.raises(
+        ValueError, match="Incomplete configuration or GitHub reference"
+    ):
         app.build()
 
 
@@ -143,6 +145,48 @@ def test_github_role_custom_link_text_produces_html_hyperlink(
         '<a class="reference external" '
         'href="https://github.com/readthedocs/readthedocs.org/issues/1">'
         "Issue #1</a>"
+    )
+
+    app.build()
+    assert app.statuscode == 0, "Build finished with problems"
+
+    path = Path(app.outdir) / "index.html"
+    assert path.exists()
+
+    content = open(path).read()
+
+    assert expected_chunk in content
+
+
+@pytest.mark.sphinx(testroot="repo-default-org")
+def test_github_role_repo_default_org_produces_html_hyperlink(
+    app: SphinxTestApp,
+) -> None:
+    expected_chunk = (
+        '<a class="reference external" '
+        'href="https://github.com/readthedocs/readthedocs.org/">'
+        "readthedocs.org</a>"
+    )
+
+    app.build()
+    assert app.statuscode == 0, "Build finished with problems"
+
+    path = Path(app.outdir) / "index.html"
+    assert path.exists()
+
+    content = open(path).read()
+
+    assert expected_chunk in content
+
+
+@pytest.mark.sphinx(testroot="repo")
+def test_github_role_repo_produces_html_hyperlink(
+    app: SphinxTestApp,
+) -> None:
+    expected_chunk = (
+        '<a class="reference external" '
+        'href="https://github.com/sphinx-doc/sphinx/">'
+        "sphinx-doc/sphinx</a>"
     )
 
     app.build()


### PR DESCRIPTION
Fixes #17

This implements the change I described in #17.

There was one required change to an existing test, since what was previously a malformed link now could now be a reference to a GitHub repository. This has produced a different failure message.

I've not spent a ton of time working with Python projects before, so let me know if there's anything you'd like changed.